### PR TITLE
Improve overall layout with sleek centered styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,9 +4,11 @@ import './index.css';
 
 function App() {
   return (
-    <div className="min-h-screen bg-gray-100 text-gray-800 p-4">
-      <h1 className="text-2xl font-bold text-center mb-4">TAMANG ORAS 🚦</h1>
-      <Home />
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-200 to-blue-400 text-gray-800 p-4">
+      <div className="w-full max-w-xl space-y-6">
+        <h1 className="text-2xl font-bold text-center text-white">TAMANG ORAS 🚦</h1>
+        <Home />
+      </div>
     </div>
   );
 }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -27,8 +27,7 @@ const Home = () => {
   }, [origin, destination, time]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-200 to-blue-400 flex items-center justify-center px-4 py-8">
-      <div className="w-full max-w-md space-y-6 text-white">
+    <div className="w-full max-w-md mx-auto space-y-6 text-white">
         <div className="glass-card p-4 text-center">
           <h2 className="text-3xl font-bold glass-heading tracking-wide mb-2">🕒 Time Now</h2>
           <p className="text-xl font-mono animate-pulse">{time.toLocaleTimeString()}</p>
@@ -54,7 +53,6 @@ const Home = () => {
         </div>
 
         <p className="text-xs text-center text-white/70 italic">Powered by TomTom Traffic API | Made by Pat Kyu</p>
-      </div>
     </div>
   );
 };

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -5,6 +5,21 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
+.glass-card {
+  backdrop-filter: blur(10px) saturate(180%);
+  -webkit-backdrop-filter: blur(10px) saturate(180%);
+  background-color: rgba(255, 255, 255, 0.25);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.glass-heading {
+  background: linear-gradient(90deg, #ffffff, #e0e0e0);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 input::placeholder {
   color: rgba(255, 255, 255, 0.6);
 }


### PR DESCRIPTION
## Summary
- refine layout in `App.js` so the app is centered on a blue gradient background
- simplify `Home` component layout and keep content centered
- add `glass-card` and `glass-heading` styles for a modern glassmorphism look

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526597e1c48324873d3b3809d016dd