### PR TITLE
Simplify layout without glass styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,9 +4,9 @@ import './index.css';
 
 function App() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-200 to-blue-400 text-gray-800 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 text-gray-800 p-4">
       <div className="w-full max-w-xl space-y-6">
-        <h1 className="text-2xl font-bold text-center text-white">TAMANG ORAS 🚦</h1>
+        <h1 className="text-2xl font-bold text-center">TAMANG ORAS 🚦</h1>
         <Home />
       </div>
     </div>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import RouteInput from './RouteInput';
 import { getSmartSuggestion } from '../utils/predictions';
 import { fetchRealTimeTraffic } from '../utils/trafficAPI';
-import '../styles/glass.css';
+
 
 const Home = () => {
   const [time, setTime] = useState(new Date());
@@ -27,13 +27,13 @@ const Home = () => {
   }, [origin, destination, time]);
 
   return (
-    <div className="w-full max-w-md mx-auto space-y-6 text-white">
-        <div className="glass-card p-4 text-center">
-          <h2 className="text-3xl font-bold glass-heading tracking-wide mb-2">🕒 Time Now</h2>
-          <p className="text-xl font-mono animate-pulse">{time.toLocaleTimeString()}</p>
+    <div className="w-full max-w-md mx-auto space-y-6 text-gray-800">
+        <div className="bg-white rounded shadow p-4 text-center">
+          <h2 className="text-3xl font-semibold mb-2">🕒 Time Now</h2>
+          <p className="text-xl font-mono">{time.toLocaleTimeString()}</p>
         </div>
 
-        <div className="glass-card p-4">
+        <div className="bg-white rounded shadow p-4">
           <RouteInput
             origin={origin}
             destination={destination}
@@ -42,17 +42,17 @@ const Home = () => {
           />
         </div>
 
-        <div className="glass-card p-4 text-center">
-          <p className="text-md text-blue-100 uppercase">Estimated Travel Time</p>
+        <div className="bg-white rounded shadow p-4 text-center">
+          <p className="text-md text-gray-600 uppercase">Estimated Travel Time</p>
           <p className="text-2xl font-semibold">{duration || 'Loading...'}</p>
         </div>
 
-        <div className="glass-card p-4 text-center">
-          <p className="text-md text-blue-100 uppercase">Traffic Suggestion</p>
+        <div className="bg-white rounded shadow p-4 text-center">
+          <p className="text-md text-gray-600 uppercase">Traffic Suggestion</p>
           <p className="text-lg font-medium">{suggestion}</p>
         </div>
 
-        <p className="text-xs text-center text-white/70 italic">Powered by TomTom Traffic API | Made by Pat Kyu</p>
+        <p className="text-xs text-center text-gray-500 italic">Powered by TomTom Traffic API | Made by Pat Kyu</p>
     </div>
   );
 };

--- a/src/components/RouteInput.js
+++ b/src/components/RouteInput.js
@@ -2,14 +2,14 @@ import React from 'react';
 
 const RouteInput = ({ origin, destination, setOrigin, setDestination }) => {
   return (
-    <div className="space-y-4 text-white">
+    <div className="space-y-4">
       <div>
         <label className="block text-sm mb-1">FROM</label>
         <input
           type="text"
           value={origin}
           onChange={(e) => setOrigin(e.target.value)}
-          className="w-full p-2 rounded bg-white/30 text-white border border-white/20 placeholder-white focus:outline-none focus:ring-2 focus:ring-blue-300"
+          className="w-full p-2 rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300"
           placeholder="e.g. Cubao"
         />
       </div>
@@ -19,7 +19,7 @@ const RouteInput = ({ origin, destination, setOrigin, setDestination }) => {
           type="text"
           value={destination}
           onChange={(e) => setDestination(e.target.value)}
-          className="w-full p-2 rounded bg-white/30 text-white border border-white/20 placeholder-white focus:outline-none focus:ring-2 focus:ring-blue-300"
+          className="w-full p-2 rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300"
           placeholder="e.g. Makati"
         />
       </div>


### PR DESCRIPTION
## Summary
- remove glass effect styles
- simplify input and card design
- keep layout centered with a plain background

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852673e60f8832492026b6276beac9a